### PR TITLE
breaking: rename repo to aerogear-app-metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
     ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/aerogear/aerogear-metrics-api
+    working_directory: /go/src/github.com/aerogear/aerogear-app-metrics
     steps:
       - run: go get github.com/mattn/goveralls
       - run: go get -u github.com/golang/dep/cmd/dep
@@ -36,7 +36,7 @@ jobs:
         ignore: /.*/
     docker:
       - image: circleci/golang:1.9
-    working_directory: /go/src/github.com/aerogear/aerogear-metrics-api
+    working_directory: /go/src/github.com/aerogear/aerogear-app-metrics
     steps:
       - run: go get github.com/goreleaser/goreleaser
       - checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ Ensure you have the following installed in your machine:
 In order to develop the Metrics API, its source code should be contained inside your `$GOPATH` and in the proper directory under `$GOPATH/src/`:
 
 ```bash
-git clone https://github.com/aerogear/aerogear-metrics-api.git $GOPATH/src/github.com/aerogear/aerogear-metrics-api
-cd aerogear-metrics-api/
+git clone https://github.com/aerogear/aerogear-app-metrics.git $GOPATH/src/github.com/aerogear/aerogear-app-metrics
+cd aerogear-app-metrics/
 ```
 
 See the [Go wiki](https://github.com/golang/go/wiki/GOPATH) for more information.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AeroGear Metrics API
+# AeroGear App Metrics
 
 This is the server component of the AeroGear Metrics Service. It is a RESTful API that allows mobile clients to send metrics data which will get stored in a PostgreSQL database. The service is written in [Golang](https://golang.org/).
 
@@ -25,7 +25,7 @@ $ echo $GOPATH
 Then clone this repository by running:
 
 ```
-git clone git@github.com:aerogear/aerogear-metrics-api.git $GOPATH/src/github.com/aerogear/aerogear-metrics-api
+git clone git@github.com:aerogear/aerogear-app-metrics.git $GOPATH/src/github.com/aerogear/aerogear-app-metrics
 ```
 
 And finally install dependencies:

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -4,10 +4,10 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/aerogear/aerogear-metrics-api/pkg/config"
-	"github.com/aerogear/aerogear-metrics-api/pkg/dao"
-	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
-	"github.com/aerogear/aerogear-metrics-api/pkg/web"
+	"github.com/aerogear/aerogear-app-metrics/pkg/config"
+	"github.com/aerogear/aerogear-app-metrics/pkg/dao"
+	"github.com/aerogear/aerogear-app-metrics/pkg/mobile"
+	"github.com/aerogear/aerogear-app-metrics/pkg/web"
 )
 
 func main() {

--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
-PKG     = github.com/aerogear/aerogear-metrics-api
+APP_NAME = aerogear-app-metrics
+PKG     = github.com/aerogear/$(APP_NAME)
 TOP_SRC_DIRS   = pkg
 PACKAGES     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
@@ -9,10 +10,10 @@ BINARY ?= metrics
 # This follows the output format for goreleaser
 BINARY_LINUX_64 = ./dist/linux_amd64/metrics
 
-DOCKER_LATEST_TAG = aerogear/aerogear-metrics-api:latest
-DOCKER_MASTER_TAG = aerogear/aerogear-metrics-api:master
+DOCKER_LATEST_TAG = aerogear/$(APP_NAME):latest
+DOCKER_MASTER_TAG = aerogear/$(APP_NAME):master
 RELEASE_TAG ?= $(CIRCLE_TAG)
-DOCKER_RELEASE_TAG = aerogear/aerogear-metrics-api:$(RELEASE_TAG)
+DOCKER_RELEASE_TAG = aerogear/$(APP_NAME):$(RELEASE_TAG)
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 

--- a/pkg/dao/dao_test.go
+++ b/pkg/dao/dao_test.go
@@ -5,7 +5,7 @@ package dao
 import (
 	"testing"
 
-	"github.com/aerogear/aerogear-metrics-api/pkg/config"
+	"github.com/aerogear/aerogear-app-metrics/pkg/config"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/pkg/dao/db_test.go
+++ b/pkg/dao/db_test.go
@@ -5,7 +5,7 @@ package dao
 import (
 	"testing"
 
-	"github.com/aerogear/aerogear-metrics-api/pkg/config"
+	"github.com/aerogear/aerogear-app-metrics/pkg/config"
 )
 
 func TestConnect(t *testing.T) {

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -1,6 +1,6 @@
 package web
 
-import "github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+import "github.com/aerogear/aerogear-app-metrics/pkg/mobile"
 
 type MetricsServiceInterface interface {
 	Create(m mobile.Metric) (mobile.Metric, error)

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+	"github.com/aerogear/aerogear-app-metrics/pkg/mobile"
 	"github.com/darahayes/go-boom"
 )
 

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+	"github.com/aerogear/aerogear-app-metrics/pkg/mobile"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
This change renames the metrics service to aerogear-app-metrics