### PR TITLE
fix: rename binary to aerogear-app-metrics & update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 .idea/
-metrics
+aerogear-app-metrics
 dist/
 coverage*.out
+.DS_Store

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@
 # Build customization
 builds:
   # makefile currently relies on this name
-  - binary: metrics
+  - binary: aerogear-app-metrics
     main: ./cmd/metrics-api/metrics-api.go
     goos:
       - windows

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7.4.1708
-ARG BINARY=./metrics
+ARG BINARY=./aerogear-app-metrics
 EXPOSE 3000
 
-COPY ${BINARY} /opt/metrics
-ENTRYPOINT ["/opt/metrics"]
+COPY ${BINARY} /opt/aerogear-app-metrics
+ENTRYPOINT ["/opt/aerogear-app-metrics"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AeroGear App Metrics
+# Aerogear App Metrics
 
-This is the server component of the AeroGear Metrics Service. It is a RESTful API that allows mobile clients to send metrics data which will get stored in a PostgreSQL database. The service is written in [Golang](https://golang.org/).
+This is the server component of the Aerogear Metrics Service. It is a RESTful API that allows mobile clients to send metrics data which will get stored in a PostgreSQL database. The service is written in [Golang](https://golang.org/).
 
 ## Prerequisites
 
@@ -73,7 +73,7 @@ make build_linux
 This binary will be used to build the Docker image. Now start the entire application.
 
 ```
-docker-comose up
+docker-compose up
 ```
 
 ### Example Client Request
@@ -121,7 +121,7 @@ The `makefile` provided provides commands for building and testing the code. For
 
 * `make build` - Compiles a binary for your current system. The binary is output at `./aerogear-app-metrics`.
 
-* `make build_linux` - Compiles a Linux compatible binary. This is mainly used for Docker builds. **Note:** `make build` should still be used if you are a Linux user.
+* `make build_linux` - Compiles a Linux compatible binary. The binary is output at `./dist/linux_amd64/aerogear-app-metrics`. This is mainly used for Docker builds. `make build` can still be used if you are a Linux user.
 
 * `make docker_build` - Builds a Binary from source and uses that binary to create a Docker image.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       args:
-        BINARY: ./dist/linux_amd64/metrics
+        BINARY: ./dist/linux_amd64/aerogear-app-metrics
     environment:
       PGHOST: db
       PGUSER: postgresql

--- a/makefile
+++ b/makefile
@@ -5,10 +5,10 @@ PACKAGES     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
                    -exec dirname {} \\; | sort | uniq")
 BIN_DIR := $(GOPATH)/bin
 SHELL = /bin/bash
-BINARY ?= metrics
+BINARY ?= aerogear-app-metrics
 
 # This follows the output format for goreleaser
-BINARY_LINUX_64 = ./dist/linux_amd64/metrics
+BINARY_LINUX_64 = ./dist/linux_amd64/aerogear-app-metrics
 
 DOCKER_LATEST_TAG = aerogear/$(APP_NAME):latest
 DOCKER_MASTER_TAG = aerogear/$(APP_NAME):master
@@ -40,6 +40,9 @@ docker_build_release:
 .PHONY: docker_build_master
 docker_build_master:
 	docker build -t $(DOCKER_MASTER_TAG) --build-arg BINARY=$(BINARY_LINUX_64) .
+
+.PHONY: test
+test: test-unit
 
 .PHONY: test-unit
 test-unit:


### PR DESCRIPTION
## Description

This PR does two things:

* Changes the default binary name from `metrics` (which is unclear) to `aerogear-app-metrics`
* Drastic improvements to the Readme

Ping @paolobueno @aliok @david-martin 