### PR TITLE
fix(tests): use t.Errorf() in types_test.go

### DIFF
--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -1,7 +1,6 @@
 package mobile
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -49,11 +48,11 @@ func TestMetricValidate(t *testing.T) {
 		valid, reason := tc.Metric.Validate()
 
 		if valid != tc.Valid {
-			fmt.Errorf("case failed: %s. Expected: %v, got %v", tc.Name, tc.Valid, valid)
+			t.Errorf("case failed: %s. Expected: %v, got %v", tc.Name, tc.Valid, valid)
 		}
 
 		if reason != tc.ExpectedReason {
-			fmt.Errorf("case failed: %s. Expected: %v, got %v", tc.Name, tc.ExpectedReason, reason)
+			t.Errorf("case failed: %s. Expected: %v, got %v", tc.Name, tc.ExpectedReason, reason)
 		}
 	}
 }


### PR DESCRIPTION
goreportcard.com made me notice this issue. We weren't actually calling `t.Errorf()` in these tests which would mean they would always fail.