### PR TITLE
fix: enhancements to config parsing and dao

### DIFF
--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -16,7 +16,7 @@ func main() {
 
 	dbHandler := dao.DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		panic("failed to connect to sql database : " + err.Error())
@@ -42,10 +42,10 @@ func main() {
 		web.HealthzRoute(router, healthHandler)
 	}
 
-	log.Printf("Starting application... going to listen on %v", config["ListenAddress"])
+	log.Printf("Starting application... going to listen on %v", config.ListenAddress)
 
 	//start
-	if err := http.ListenAndServe(config["ListenAddress"], router); err != nil {
+	if err := http.ListenAndServe(config.ListenAddress, router); err != nil {
 		panic("failed to start " + err.Error())
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,24 @@ package config
 import (
 	"fmt"
 	"os"
+	"sort"
+	"strconv"
+	"strings"
 )
+
+type config struct {
+	DBConnectionString string
+	DBMaxConnections   int
+	ListenAddress      string
+}
+
+func GetConfig() config {
+	return config{
+		DBConnectionString: getDBConnectionString(),
+		DBMaxConnections:   getEnvInt("DBMAX_CONNECTIONS", 100),
+		ListenAddress:      fmt.Sprintf(":%v", getEnvInt("PORT", 3000)),
+	}
+}
 
 // Simple helper function to read an environment or return a default value
 func getEnv(key string, defaultVal string) string {
@@ -13,13 +30,46 @@ func getEnv(key string, defaultVal string) string {
 	return defaultVal
 }
 
-func GetConfig() map[string]string {
-	return map[string]string{
-		"DBHost":        getEnv("PGHOST", "localhost"),
-		"DBUser":        getEnv("PGUSER", "postgresql"),
-		"DBPassword":    getEnv("PGPASSWORD", "postgres"),
-		"DBName":        getEnv("PGDATABASE", "aerogear_mobile_metrics"),
-		"SSLMode":       getEnv("PGSSLMODE", "disable"),
-		"ListenAddress": fmt.Sprintf(":%s", getEnv("PORT", "3000")),
+// Simple helper function to read an environment variable into integer or return a default value
+func getEnvInt(name string, defaultVal int) int {
+	valueStr := getEnv(name, "")
+	if value, err := strconv.Atoi(valueStr); err == nil {
+		return value
 	}
+	return defaultVal
+}
+
+// builds a libpq compatible connection string e.g. "user=postgresql host=localhost password=postgres"
+func getDBConnectionString() string {
+
+	// These are all of the options supported by pq
+	dbConnectionConfig := map[string]string{
+		"dbname":                    getEnv("PGDATABASE", "aerogear_mobile_metrics"),
+		"user":                      getEnv("PGUSER", "postgresql"),
+		"password":                  getEnv("PGPASSWORD", "postgres"),
+		"host":                      getEnv("PGHOST", "localhost"),
+		"port":                      getEnv("PGPORT", "5432"),
+		"sslmode":                   getEnv("PGSSLMODE", "disable"),
+		"connect_timeout":           getEnv("PGCONNECT_TIMEOUT", "5"),
+		"fallback_application_name": getEnv("PGAPPNAME", ""),
+		"sslcert":                   getEnv("PGSSLCERT", ""),
+		"sslkey":                    getEnv("PGSSLKEY", ""),
+		"sslrootcert":               getEnv("PGSSLROOTCERT", ""),
+	}
+
+	var options []string
+
+	// build the list of options such as "user=postgresql"
+	// omit any unset options
+	for k, v := range dbConnectionConfig {
+		if dbConnectionConfig[k] != "" {
+			options = append(options, fmt.Sprintf("%v=%v", k, v))
+		}
+	}
+
+	// sort the list (because ordering in maps is random)
+	// this ensures connection string is the same every time. Makes testing much easier
+	sort.Strings(options)
+
+	return strings.Join(options, " ")
 }

--- a/pkg/dao/dao_test.go
+++ b/pkg/dao/dao_test.go
@@ -1,5 +1,4 @@
 // +build integration
-
 package dao
 
 import (
@@ -17,7 +16,7 @@ func TestIsHealthy(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -40,7 +39,7 @@ func TestIsHealthyWhenDisconnected(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -65,7 +64,7 @@ func TestCreate(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -93,7 +92,7 @@ func TestCreateBadJSON(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -115,7 +114,7 @@ func TestCreateEmptyClientID(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -49,7 +49,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(30) NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(128) NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(128) NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -3,7 +3,6 @@ package dao
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -13,16 +12,16 @@ type DatabaseHandler struct {
 	DB *sql.DB
 }
 
-func (handler *DatabaseHandler) Connect(dbHost, dbUser, dbPassword, dbName, sslMode string) error {
+func (handler *DatabaseHandler) Connect(connStr string, maxConnections int) error {
 	if handler.DB != nil {
 		return nil
 	}
 
-	connStr := fmt.Sprintf("host=%v user=%v password=%v dbname=%v sslmode=%v", dbHost, dbUser, dbPassword, dbName, sslMode)
-
 	// sql.Open doesn't initialize the connection immediately
 	dbInstance, err := sql.Open("postgres", connStr)
 	handler.DB = dbInstance
+
+	dbInstance.SetMaxOpenConns(maxConnections)
 
 	// an error can happen here if the connection string is invalid
 	if err != nil {

--- a/pkg/dao/db_test.go
+++ b/pkg/dao/db_test.go
@@ -1,5 +1,4 @@
 // +build integration
-
 package dao
 
 import (
@@ -12,7 +11,7 @@ func TestConnect(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -29,13 +28,13 @@ func TestConnectAlreadyConnected(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
 	}
 
-	err = dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err = dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -46,7 +45,7 @@ func TestDisconnect(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -79,7 +78,7 @@ func TestDoInitialSetup(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
+	err := dbHandler.Connect(config.DBConnectionString, config.DBMaxConnections)
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -1,5 +1,9 @@
 package mobile
 
+import (
+	"fmt"
+)
+
 type AppConfig struct {
 	DBConnectionString string
 }
@@ -28,9 +32,17 @@ type DeviceMetric struct {
 	PlatformVersion string `json:"platformVersion"`
 }
 
+const clientIdMaxLength = 128
+
+var clientIdLengthError = fmt.Sprintf("clientId exceeded maximum length of %v", clientIdMaxLength)
+
 func (m *Metric) Validate() (valid bool, reason string) {
 	if m.ClientId == "" {
 		return false, "missing clientId in payload"
+	}
+
+	if len(m.ClientId) > clientIdMaxLength {
+		return false, clientIdLengthError
 	}
 
 	// check if data field was missing or empty object

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -22,7 +22,7 @@ type MetricData struct {
 }
 
 type AppMetric struct {
-	ID         string `json:"id"`
+	ID         string `json:"appId"`
 	SDKVersion string `json:"sdkVersion"`
 	AppVersion string `json:"appVersion"`
 }

--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -1,6 +1,8 @@
 package mobile
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -23,6 +25,12 @@ func TestMetricValidate(t *testing.T) {
 			Metric:         Metric{Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
 			Valid:          false,
 			ExpectedReason: "missing clientId in payload",
+		},
+		{
+			Name:           "Metric with long clientId should be invalid",
+			Metric:         Metric{ClientId: strings.Join(make([]string, clientIdMaxLength+10), "a"), Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Valid:          false,
+			ExpectedReason: fmt.Sprintf("clientId exceeded maximum length of %v", clientIdMaxLength),
 		},
 		{
 			Name:           "Metric with no Data should be invalid",


### PR DESCRIPTION
This PR introduces a number of enhancements: 

* Client ID max length is now enforced at the business logic layer using metric.Validate(). This allows us to respond with a proper message when the max length has been exceeded. Ping @psturc.
* the dao package now has some small amount of retry logic which will let the server retry connecting to the db for up to 5 seconds before failing. This solves a minor issue particularly in docker-compose where the server sometimes starts before the database is ready to accept connections. Ping @josemigallas.
* Configuration parsing has been hardened and refactored. All connection options supported by the postgres driver are now supported and the connection string can be dynamically generated based off what config/env vars are present. This means we won't need to do any refactoring of the DB connection in the future.
* The dao package now calls `db.SetMaxOpenConns()` with a default of 100 which is apparently the default allowed by Postgres. [See docs](https://www.postgresql.org/docs/9.6/static/runtime-config-connection.html).

## Verification

Delete all containers previously run by docker-compose. You can get the container IDs with the following `docker ps -a | grep aerogearappmetrics`

Then run `docker rm <id>` for each id.

Then forcefully recreate your docker-compose environment with the following:

```
docker-compose up --build --force-recreate
```

You should notice 2 things:

1. The metrics server did not crash while trying to connect to the database.

2. Make the following curl request:

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 7011091f-b785-2c89-bfe8-55383df253f9' \
  -d '{
  "clientId": "453de743211112345678900987654312345678908776423567890876543678907654356789076543536789765436789076543256789076543256789654321456789654321456789765432567869765432567896543256789765432145678976543214567897654324567896543214567897654321245678976543256789765432145678965432567896543256786543214567865432",
  "data": {
    "app": {
      "id": "com.example.someApp",
      "sdkVersion": "2.4.6",
      "appVersion": "256"
    },
    "device": {
      "platform": "android",
      "platformVersion": "27"
    }
  }
}'
```

And you should see the following message:

```
{
    "error": "Bad Request",
    "message": "clientId exceeded maximum length of 128",
    "statusCode": 400
}
```