### PR TITLE
fix: initial logging implementation using logrus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
+  version = "v1.0.4"
+
+[[projects]]
   name = "github.com/stretchr/objx"
   packages = ["."]
   revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
@@ -55,9 +61,24 @@
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  revision = "91a49db82a88618983a78a06c1cbd4e00ab749ab"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "f6cff0780e542efa0c8e864dc8fa522808f6a598"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c56cca0c33a9947373eeed4372b6600c13eed5ce8389ca649bdb4fb3679f2c66"
+  inputs-digest = "3b1e50fe760cfd9c5026f70740752628d75ed56ec43f7a59f5dc396b33f7a0a2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,3 +17,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.1"
+
+[[constraint]]
+  name = "github.com/sirupsen/logrus"
+  version = "1.0.4"

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -1,18 +1,20 @@
 package main
 
 import (
-	"log"
 	"net/http"
 
 	"github.com/aerogear/aerogear-app-metrics/pkg/config"
 	"github.com/aerogear/aerogear-app-metrics/pkg/dao"
 	"github.com/aerogear/aerogear-app-metrics/pkg/mobile"
 	"github.com/aerogear/aerogear-app-metrics/pkg/web"
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
 
 	config := config.GetConfig()
+
+	initLogger(config.LogLevel, config.LogFormat)
 
 	dbHandler := dao.DatabaseHandler{}
 
@@ -42,10 +44,27 @@ func main() {
 		web.HealthzRoute(router, healthHandler)
 	}
 
-	log.Printf("Starting application... going to listen on %v", config.ListenAddress)
+	log.WithFields(log.Fields{"listenAddress": config.ListenAddress}).Info("Starting application")
 
 	//start
 	if err := http.ListenAndServe(config.ListenAddress, router); err != nil {
 		panic("failed to start " + err.Error())
+	}
+}
+
+func initLogger(level, format string) {
+	logLevel, err := log.ParseLevel(level)
+
+	if err != nil {
+		logLevel = log.InfoLevel
+	}
+
+	log.SetLevel(logLevel)
+
+	switch format {
+	case "json":
+		log.SetFormatter(&log.JSONFormatter{})
+	default:
+		log.SetFormatter(&log.TextFormatter{DisableColors: true})
 	}
 }

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -56,6 +56,7 @@ func initLogger(level, format string) {
 	logLevel, err := log.ParseLevel(level)
 
 	if err != nil {
+		log.Fatalf("log level %v is not allowed. Must be one of [debug, info, warning, error, fatal, panic]", level)
 		logLevel = log.InfoLevel
 	}
 
@@ -64,7 +65,9 @@ func initLogger(level, format string) {
 	switch format {
 	case "json":
 		log.SetFormatter(&log.JSONFormatter{})
-	default:
+	case "text":
 		log.SetFormatter(&log.TextFormatter{DisableColors: true})
+	default:
+		log.Fatalf("log format %v is not allowed. Must be one of [text, json]", format)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ func GetConfig() config {
 		DBMaxConnections:   getEnvInt("DBMAX_CONNECTIONS", 100),
 		ListenAddress:      fmt.Sprintf(":%v", getEnvInt("PORT", 3000)),
 		LogLevel:           strings.ToLower(getEnv("LOG_LEVEL", "info")),
-		LogFormat:          strings.ToLower(getEnv("LOG_FORMAT", "text")),
+		LogFormat:          strings.ToLower(getEnv("LOG_FORMAT", "text")), //can be text or json
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,8 @@ type config struct {
 	DBConnectionString string
 	DBMaxConnections   int
 	ListenAddress      string
+	LogLevel           string
+	LogFormat          string
 }
 
 func GetConfig() config {
@@ -19,6 +21,8 @@ func GetConfig() config {
 		DBConnectionString: getDBConnectionString(),
 		DBMaxConnections:   getEnvInt("DBMAX_CONNECTIONS", 100),
 		ListenAddress:      fmt.Sprintf(":%v", getEnvInt("PORT", 3000)),
+		LogLevel:           strings.ToLower(getEnv("LOG_LEVEL", "info")),
+		LogFormat:          strings.ToLower(getEnv("LOG_FORMAT", "text")),
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,6 +19,8 @@ func TestConfig(t *testing.T) {
 				ListenAddress:      ":3000",
 				DBMaxConnections:   100,
 				DBConnectionString: "connect_timeout=5 dbname=aerogear_mobile_metrics host=localhost password=postgres port=5432 sslmode=disable user=postgresql",
+				LogFormat:          "text",
+				LogLevel:           "info",
 			},
 			EnvVars: map[string]string{},
 		},
@@ -28,6 +30,8 @@ func TestConfig(t *testing.T) {
 				ListenAddress:      ":3000",
 				DBMaxConnections:   100,
 				DBConnectionString: "connect_timeout=5 dbname=testing host=testing password=testing port=5432 sslmode=testing user=testing",
+				LogFormat:          "testing",
+				LogLevel:           "testing",
 			},
 			EnvVars: map[string]string{
 				"PGHOST":     "testing",
@@ -35,6 +39,8 @@ func TestConfig(t *testing.T) {
 				"PGPASSWORD": "testing",
 				"PGDATABASE": "testing",
 				"PGSSLMODE":  "testing",
+				"LOG_LEVEL":  "testing",
+				"LOG_FORMAT": "testing",
 			},
 		},
 		{
@@ -43,6 +49,8 @@ func TestConfig(t *testing.T) {
 				ListenAddress:      ":3000",
 				DBMaxConnections:   100,
 				DBConnectionString: "connect_timeout=5 dbname=aerogear_mobile_metrics host=localhost password=postgres port=5432 sslmode=disable user=postgresql",
+				LogFormat:          "text",
+				LogLevel:           "info",
 			},
 			EnvVars: map[string]string{
 				"PGHOST":     "",
@@ -51,6 +59,8 @@ func TestConfig(t *testing.T) {
 				"PGDATABASE": "",
 				"PGSSLMODE":  "",
 				"PORT":       "",
+				"LOG_LEVEL":  "",
+				"LOG_FORMAT": "",
 			},
 		},
 		{
@@ -59,6 +69,8 @@ func TestConfig(t *testing.T) {
 				ListenAddress:      ":4000",
 				DBMaxConnections:   5,
 				DBConnectionString: "connect_timeout=5 dbname=aerogear_mobile_metrics host=localhost password=postgres port=5432 sslmode=disable user=postgresql",
+				LogFormat:          "text",
+				LogLevel:           "info",
 			},
 			EnvVars: map[string]string{
 				"DBMAX_CONNECTIONS": "5",
@@ -71,6 +83,8 @@ func TestConfig(t *testing.T) {
 				ListenAddress:      ":3000",
 				DBMaxConnections:   100,
 				DBConnectionString: "connect_timeout=5 dbname=aerogear_mobile_metrics host=localhost password=postgres port=5432 sslmode=disable user=postgresql",
+				LogFormat:          "text",
+				LogLevel:           "info",
 			},
 			EnvVars: map[string]string{
 				"DBMAX_CONNECTIONS": "not an integer",

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(128) NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(128) NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aerogear/aerogear-app-metrics/pkg/mobile"
 	"github.com/darahayes/go-boom"
+	log "github.com/sirupsen/logrus"
 )
 
 type metricsHandler struct {
@@ -23,11 +24,13 @@ func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 
 	// decode the client payload into the metric var
 	if err := json.NewDecoder(r.Body).Decode(&metric); err != nil {
-		boom.BadRequest(w, "Invalid Data")
+		log.WithFields(log.Fields{"error": err.Error()}).Error("error parsing client payload")
+		boom.BadRequest(w, "invalid JSON payload")
 		return
 	}
 
 	if valid, reason := metric.Validate(); !valid {
+		log.WithFields(log.Fields{"reason": reason}).Info("invalid client payload")
 		boom.BadRequest(w, reason)
 		return
 	}
@@ -37,11 +40,13 @@ func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 
 	// handle errors
 	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("error creating metric")
 		boom.BadImplementation(w)
 		return
 	}
 
 	if err := withJSON(w, 200, result); err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("error responding to client")
 		boom.BadImplementation(w)
 		return
 	}

--- a/pkg/web/middlewares.go
+++ b/pkg/web/middlewares.go
@@ -1,9 +1,10 @@
 package web
 
 import (
-	"log"
 	"net/http"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func loggerMiddleWare(next http.Handler) http.Handler {
@@ -12,12 +13,12 @@ func loggerMiddleWare(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 
-		log.Printf(
-			"%s\t%s\t%s",
-			r.Method,
-			r.RequestURI,
-			time.Since(start),
-		)
+		log.WithFields(log.Fields{
+			"method":        r.Method,
+			"path":          r.RequestURI,
+			"client_ip":     r.RemoteAddr,
+			"response_time": time.Since(start),
+		}).Info()
 	})
 }
 


### PR DESCRIPTION
This introduces logging using the popular library [logrus](https://github.com/sirupsen/logrus). Most of the logging is in the MetricsHandler because this is where all the action happens.

The logs have 6 different log levels as defined by logrus:

* Debug
* Info
* Warning
* Error
* Fatal
* Panic

The logs can be displayed in two different formats, `text` or `json`.

example of a text log:

```
time="2018-03-01T15:20:57Z" level=info msg="Starting application" listenAddress=":3000"
```

example of the same log in json:

```
{"level":"info","listenAddress":":3000","msg":"Starting application","time":"2018-03-01T15:21:32Z"}
```

Log levels and log format can be configured with the following env variables:

* `LOG_LEVEL`
	* can be one of [debug, info, warning, error, fatal, panic]
	* default is `info`
	* for robustness I've made it case insensitive
* `LOG_FORMAT`
	* can be one of [json, text]
	* default is `text` - for readibility during development
	* case insensitive
	* Perhaps the `json` option is useful in 'Production' scenarios for log aggregation/analysis technologies like logstash or splunk.

ping @david-martin @maleck13 