### PR TITLE
feat: initial parsing of security metrics

### DIFF
--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -50,7 +50,7 @@ const invalidTimestampError = "timestamp must be a valid number"
 const missingDataError = "missing metrics data in payload"
 const securityMetricsEmptyError = "data.security cannot be empty"
 const securityMetricMissingTypeError = "invalid element in data.security at position %v, type must be included"
-const securityMetricMissingNameError = "invalid element in data.security at position %v, type must be included"
+const securityMetricMissingNameError = "invalid element in data.security at position %v, name must be included"
 const securityMetricMissingPassedError = "invalid element in data.security at position %v, passed must be included"
 
 var clientIdLengthError = fmt.Sprintf("clientId exceeded maximum length of %v", clientIdMaxLength)

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -18,8 +18,9 @@ type Metric struct {
 }
 
 type MetricData struct {
-	App    *AppMetric    `json:"app,omitempty"`
-	Device *DeviceMetric `json:"device,omitempty"`
+	App      *AppMetric       `json:"app,omitempty"`
+	Device   *DeviceMetric    `json:"device,omitempty"`
+	Security *SecurityMetrics `json:"security,omitempty"`
 }
 
 type AppMetric struct {
@@ -31,6 +32,18 @@ type AppMetric struct {
 type DeviceMetric struct {
 	Platform        string `json:"platform"`
 	PlatformVersion string `json:"platformVersion"`
+}
+
+type SecurityMetrics struct {
+	EmulatorCheck      *SecurityMetric `json:"org.aerogear.mobile.security.checks.EmulatorCheck,omitempty,string"`
+	DeveloperModeCheck *SecurityMetric `json:"org.aerogear.mobile.security.checks.DeveloperModeCheck,omitempty,string"`
+	DebuggerCheck      *SecurityMetric `json:"org.aerogear.mobile.security.checks.DebuggerCheck,omitempty,string"`
+	RootedCheck        *SecurityMetric `json:"org.aerogear.mobile.security.checks.RootedCheck,omitempty,string"`
+	ScreenLockCheck    *SecurityMetric `json:"org.aerogear.mobile.security.checks.ScreenLockCheck,omitempty,string"`
+}
+
+type SecurityMetric struct {
+	Passed bool `json:"passed"`
 }
 
 const clientIdMaxLength = 128

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -34,16 +34,11 @@ type DeviceMetric struct {
 	PlatformVersion string `json:"platformVersion"`
 }
 
-type SecurityMetrics struct {
-	EmulatorCheck      *SecurityMetric `json:"org.aerogear.mobile.security.checks.EmulatorCheck,omitempty,string"`
-	DeveloperModeCheck *SecurityMetric `json:"org.aerogear.mobile.security.checks.DeveloperModeCheck,omitempty,string"`
-	DebuggerCheck      *SecurityMetric `json:"org.aerogear.mobile.security.checks.DebuggerCheck,omitempty,string"`
-	RootedCheck        *SecurityMetric `json:"org.aerogear.mobile.security.checks.RootedCheck,omitempty,string"`
-	ScreenLockCheck    *SecurityMetric `json:"org.aerogear.mobile.security.checks.ScreenLockCheck,omitempty,string"`
-}
+type SecurityMetrics []SecurityMetric
 
 type SecurityMetric struct {
-	Passed bool `json:"passed"`
+	Type   string `json:"type"`
+	Passed bool   `json:"passed"`
 }
 
 const clientIdMaxLength = 128

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -38,6 +38,7 @@ type SecurityMetrics []SecurityMetric
 
 type SecurityMetric struct {
 	Type   *string `json:"type,omitempty"`
+	Name   *string `json:"name,omitempty"`
 	Passed *bool   `json:"passed,omitempty"`
 }
 
@@ -49,6 +50,7 @@ const invalidTimestampError = "timestamp must be a valid number"
 const missingDataError = "missing metrics data in payload"
 const securityMetricsEmptyError = "data.security cannot be empty"
 const securityMetricMissingTypeError = "invalid element in data.security at position %v, type must be included"
+const securityMetricMissingNameError = "invalid element in data.security at position %v, type must be included"
 const securityMetricMissingPassedError = "invalid element in data.security at position %v, passed must be included"
 
 var clientIdLengthError = fmt.Sprintf("clientId exceeded maximum length of %v", clientIdMaxLength)
@@ -84,6 +86,9 @@ func (m *Metric) Validate() (valid bool, reason string) {
 		for i, sm := range *m.Data.Security {
 			if sm.Type == nil {
 				return false, fmt.Sprintf(securityMetricMissingTypeError, i)
+			}
+			if sm.Name == nil {
+				return false, fmt.Sprintf(securityMetricMissingNameError, i)
 			}
 			if sm.Passed == nil {
 				return false, fmt.Sprintf(securityMetricMissingPassedError, i)

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -47,11 +47,12 @@ const securityMetricsMaxLength = 30
 const clientIdMissingError = "missing clientId in payload"
 const invalidTimestampError = "timestamp must be a valid number"
 const missingDataError = "missing metrics data in payload"
-const clientIdLengthError = "clientId exceeded maximum length of " + string(clientIdMaxLength)
-const securityMetricsLengthError = "maximum length of data.security is " + string(securityMetricsMaxLength)
 const securityMetricsEmptyError = "data.security cannot be empty"
 const securityMetricMissingTypeError = "invalid element in data.security at position %v, type must be included"
 const securityMetricMissingPassedError = "invalid element in data.security at position %v, passed must be included"
+
+var clientIdLengthError = fmt.Sprintf("clientId exceeded maximum length of %v", clientIdMaxLength)
+var securityMetricsLengthError = fmt.Sprintf("maximum length of data.security %v", securityMetricsMaxLength)
 
 func (m *Metric) Validate() (valid bool, reason string) {
 	if m.ClientId == "" {

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -44,7 +44,7 @@ type SecurityMetric struct {
 const clientIdMaxLength = 128
 const securityMetricsMaxLength = 30
 
-const clientIdMissingError = "missing clientId in payload"
+const missingClientIdError = "missing clientId in payload"
 const invalidTimestampError = "timestamp must be a valid number"
 const missingDataError = "missing metrics data in payload"
 const securityMetricsEmptyError = "data.security cannot be empty"
@@ -56,7 +56,7 @@ var securityMetricsLengthError = fmt.Sprintf("maximum length of data.security %v
 
 func (m *Metric) Validate() (valid bool, reason string) {
 	if m.ClientId == "" {
-		return false, clientIdMissingError
+		return false, missingClientIdError
 	}
 
 	if len(m.ClientId) > clientIdMaxLength {

--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -9,6 +9,7 @@ import (
 func TestMetricValidate(t *testing.T) {
 
 	securityMetricType := "org.aerogear.mobile.security.checks.TestCheck"
+	securityMetricName := "TestCheck"
 	securityMetricPassed := true
 
 	bigSecurityMetricList := SecurityMetrics{}
@@ -72,13 +73,19 @@ func TestMetricValidate(t *testing.T) {
 		},
 		{
 			Name:           "Security Metrics with missing type field should be invalid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: nil, Passed: &securityMetricPassed}}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: nil, Name: &securityMetricName, Passed: &securityMetricPassed}}}},
 			Valid:          false,
 			ExpectedReason: fmt.Sprintf(securityMetricMissingTypeError, 0),
 		},
 		{
+			Name:           "Security Metrics with missing name field should be invalid",
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: &securityMetricType, Name: nil, Passed: &securityMetricPassed}}}},
+			Valid:          false,
+			ExpectedReason: fmt.Sprintf(securityMetricMissingNameError, 0),
+		},
+		{
 			Name:           "Security Metrics with missing passed field should be invalid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: &securityMetricType, Passed: nil}}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: &securityMetricType, Name: &securityMetricName, Passed: nil}}}},
 			Valid:          false,
 			ExpectedReason: fmt.Sprintf(securityMetricMissingPassedError, 0),
 		},


### PR DESCRIPTION
The result of this PR is that the server expects a payload as follows:

```
{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "type": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "name": "Developer Mode Check",
        "passed": true
      },
     {
        "type": "org.aerogear.mobile.security.checks.EmulatorCheck",
        "name": "Emulator Check",
        "passed": false
      },
      {
        "type": "org.aerogear.mobile.security.checks.DebuggerCheck",
        "name": "Debugger Check",
        "passed": false
      },
      {
        "type": "org.aerogear.mobile.security.checks.RootedCheck",
        "name": "Rooted Check",
        "passed": false
      },
      {
        "type": "org.aerogear.mobile.security.checks.ScreenLockCheck",
        "name": "Screen Lock Check",
        "passed": false
      }
    ]
  }
}
```

There is also some basic validation logic for the security metrics. The following is validations are in place:

* max length is 30 (total guess)
* if list is empty, reject the request. e.g. client explicitly passes `{"security:" []}`
* if `type`, `name` or `passed` fields are not present then the request is rejected

## Verification Steps

To make verification easier, start with a fresh database by deleting the old db container cached by docker-compose. Do the following:

* docker ps -a | grep db_1
* `docker rm` the ids of any containers returned back by the previous command
* restart the db using `docker-compose up --force-recreate --build db`

For each case we are going to make a `curl` request and then check the results in the database.

Logging into the database and checking the contents of the `mobileappmetrics` table can be done as follows:

```
psql -U postgresql -d aerogear_mobile_metrics --host localhost
Password for user postgresql: #postgres

aerogear_mobile_metrics=> select * from mobileappmetrics;
```

For each section below, perform the curl request and then check the database for the expected result. We are going to test the following cases:

1. The normal case - All checks and data are present
2. Some Checks are present
3. Case where `type` field is missing
4. Case where `name` field is missing
5. Case where `passed` field is missing
6. Case where empty security array is sent
7. Case where no security array is sent

### 1. The normal case - All checks and data are present

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 6db8f0ae-4e9e-1ae1-530b-138b1a87bfe7' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "type": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "name": "Developer Mode Check",
        "passed": true
      },
     {
        "type": "org.aerogear.mobile.security.checks.EmulatorCheck",
        "name": "Emulator Check",
        "passed": false
      },
      {
        "type": "org.aerogear.mobile.security.checks.DebuggerCheck",
        "name": "Debugger Check",
        "passed": false
      },
      {
        "type": "org.aerogear.mobile.security.checks.RootedCheck",
        "name": "Rooted Check",
        "passed": false
      },
      {
        "type": "org.aerogear.mobile.security.checks.ScreenLockCheck",
        "name": "Screen Lock Check",
        "passed": false
      }
    ]
  }
}
'
```

#### Expected Results

200 ok, data is inserted into the db as expected

### 2. Some Checks are present

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: c55b290a-18c7-c522-5965-72e76c965231' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "type": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "name": "Developer Mode Check",
        "passed": true
      }
    ]
  }
}
'
```

#### Expected Results

200 ok, data is inserted into the db as expected

### 3. Case where `type` field is missing

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 223c5e31-6d66-dbf6-b10c-a575219ec8dc' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "name": "Developer Mode Check",
        "passed": true
      }
    ]
  }
}
'
```

#### Expected results:

```
{
    "error": "Bad Request",
    "message": "invalid element in data.security at position 0, type must be included",
    "statusCode": 400
}
```

No records inserted into database

### 4. Case where `name` field is missing

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 3ba48670-d29a-45c9-2a35-a0110e15de01' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "type": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "passed": true
      }
    ]
  }
}
'
```

#### Expected Result

```
{
    "error": "Bad Request",
    "message": "invalid element in data.security at position 0, name must be included",
    "statusCode": 400
}
```

No records inserted into database

### 5. Case where `passed` field is missing

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 64cfd0dc-245d-fe97-8fac-d5c8cabe75e6' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "type": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "name": "Developer Mode Check"
      }
    ]
  }
}
'
```

#### Expected Result

```
{
    "error": "Bad Request",
    "message": "invalid element in data.security at position 0, passed must be included",
    "statusCode": 400
}
```

No records inserted into database

### 6. Case where empty checks array is sent

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 56333917-05cc-d4c3-c4cc-d1716083c242' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      
    ]
  }
}
'
```

#### Expected Result

```
{
    "error": "Bad Request",
    "message": "data.security cannot be empty",
    "statusCode": 400
}
```

No records stored in database

### 7. Case where no security array is sent

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 0fed33ac-1fe2-3165-e925-df833e1e9d97' \
  -d '{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    
  }
}
'
```

#### Expected Result

```
{
    "error": "Bad Request",
    "message": "missing metrics data in payload",
    "statusCode": 400
}
```
