### PR TITLE
fix: clean up test commands in makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     working_directory: /go/src/github.com/aerogear/aerogear-app-metrics
 
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.10
       - image: registry.access.redhat.com/rhscl/postgresql-96-rhel7:latest
         ports:
           - 5432:5432

--- a/makefile
+++ b/makefile
@@ -47,20 +47,20 @@ test: test-unit
 .PHONY: test-unit
 test-unit:
 	@echo Running tests:
-	go test -v -race -cover $(UNIT_TEST_FLAGS) \
+	GOCACHE=off go test -cover \
 	  $(addprefix $(PKG)/,$(PACKAGES))
 
 .PHONY: test-integration
 test-integration:
 	@echo Running tests:
-	go test -v -race -cover $(UNIT_TEST_FLAGS) -tags=integration \
+	GOCACHE=off go test -failfast -cover -tags=integration \
 	  $(addprefix $(PKG)/,$(PACKAGES))
 
 .PHONY: test-integration-cover
 test-integration-cover:
 	echo "mode: count" > coverage-all.out
-	$(foreach pkg,$(PACKAGES),\
-		go test -tags=integration -coverprofile=coverage.out -covermode=count $(addprefix $(PKG)/,$(pkg)) || exit 1;\
+	GOCACHE=off $(foreach pkg,$(PACKAGES),\
+		go test -failfast -tags=integration -coverprofile=coverage.out -covermode=count $(addprefix $(PKG)/,$(pkg)) || exit 1;\
 		tail -n +2 coverage.out >> coverage-all.out;)
 
 .PHONY: errcheck


### PR DESCRIPTION
This PR adds the GOCACHE=off flag which ensures test results are not cached in between test runs. The reason for this is the integration tests were reporting passing tests even though the database was not running.

Additionally, it adds a `-failfast` option to the integration tests. This ensures the tests fail after the first test case failure. The reason for adding this is because the integration tests hang for up to a minute as each test calls `Connect()` (if the database is not running)

### Verification:

* start the database using `docker-compose up db`
* run `make test-integration`
	* Tests should pass
	* You shouldn't see any server logs
* now kill the database container
* now run `make test-integration` again
	* tests should not pass

Ping @psturc 