### PR TITLE
breaking: rename Type field in SecurityMetric to Id

### DIFF
--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -37,7 +37,7 @@ type DeviceMetric struct {
 type SecurityMetrics []SecurityMetric
 
 type SecurityMetric struct {
-	Type   *string `json:"type,omitempty"`
+	Id     *string `json:"id,omitempty"`
 	Name   *string `json:"name,omitempty"`
 	Passed *bool   `json:"passed,omitempty"`
 }
@@ -49,7 +49,7 @@ const missingClientIdError = "missing clientId in payload"
 const invalidTimestampError = "timestamp must be a valid number"
 const missingDataError = "missing metrics data in payload"
 const securityMetricsEmptyError = "data.security cannot be empty"
-const securityMetricMissingTypeError = "invalid element in data.security at position %v, type must be included"
+const securityMetricMissingIdError = "invalid element in data.security at position %v, id must be included"
 const securityMetricMissingNameError = "invalid element in data.security at position %v, name must be included"
 const securityMetricMissingPassedError = "invalid element in data.security at position %v, passed must be included"
 
@@ -84,8 +84,8 @@ func (m *Metric) Validate() (valid bool, reason string) {
 			return false, securityMetricsLengthError
 		}
 		for i, sm := range *m.Data.Security {
-			if sm.Type == nil {
-				return false, fmt.Sprintf(securityMetricMissingTypeError, i)
+			if sm.Id == nil {
+				return false, fmt.Sprintf(securityMetricMissingIdError, i)
 			}
 			if sm.Name == nil {
 				return false, fmt.Sprintf(securityMetricMissingNameError, i)

--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestMetricValidate(t *testing.T) {
 
-	securityMetricType := "org.aerogear.mobile.security.checks.TestCheck"
+	securityMetricId := "org.aerogear.mobile.security.checks.TestCheck"
 	securityMetricName := "TestCheck"
 	securityMetricPassed := true
 
 	bigSecurityMetricList := SecurityMetrics{}
 	for i := 0; i <= clientIdMaxLength+1; i++ {
-		bigSecurityMetricList = append(bigSecurityMetricList, SecurityMetric{Type: &securityMetricType, Passed: &securityMetricPassed})
+		bigSecurityMetricList = append(bigSecurityMetricList, SecurityMetric{Id: &securityMetricId, Passed: &securityMetricPassed})
 	}
 
 	testCases := []struct {
@@ -73,19 +73,19 @@ func TestMetricValidate(t *testing.T) {
 		},
 		{
 			Name:           "Security Metrics with missing type field should be invalid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: nil, Name: &securityMetricName, Passed: &securityMetricPassed}}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Id: nil, Name: &securityMetricName, Passed: &securityMetricPassed}}}},
 			Valid:          false,
-			ExpectedReason: fmt.Sprintf(securityMetricMissingTypeError, 0),
+			ExpectedReason: fmt.Sprintf(securityMetricMissingIdError, 0),
 		},
 		{
 			Name:           "Security Metrics with missing name field should be invalid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: &securityMetricType, Name: nil, Passed: &securityMetricPassed}}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Id: &securityMetricId, Name: nil, Passed: &securityMetricPassed}}}},
 			Valid:          false,
 			ExpectedReason: fmt.Sprintf(securityMetricMissingNameError, 0),
 		},
 		{
 			Name:           "Security Metrics with missing passed field should be invalid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Type: &securityMetricType, Name: &securityMetricName, Passed: nil}}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Id: &securityMetricId, Name: &securityMetricName, Passed: nil}}}},
 			Valid:          false,
 			ExpectedReason: fmt.Sprintf(securityMetricMissingPassedError, 0),
 		},

--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -72,7 +72,7 @@ func TestMetricValidate(t *testing.T) {
 			ExpectedReason: "",
 		},
 		{
-			Name:           "Security Metrics with missing type field should be invalid",
+			Name:           "Security Metrics with missing id field should be invalid",
 			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{Security: &SecurityMetrics{SecurityMetric{Id: nil, Name: &securityMetricName, Passed: &securityMetricPassed}}}},
 			Valid:          false,
 			ExpectedReason: fmt.Sprintf(securityMetricMissingIdError, 0),


### PR DESCRIPTION
With this PR, application now accepts the following security related payload.

```
{
  "clientId": "9796fb69-a566-43fb-b932-03951d82437f",
  "timestamp": 1519989859342,
  "data": {
    "security": [
      {
        "id": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "name": "Developer Mode Check",
        "passed": true
      },
     {
        "id": "org.aerogear.mobile.security.checks.EmulatorCheck",
        "name": "Emulator Check",
        "passed": false
      },
      {
        "id": "org.aerogear.mobile.security.checks.DebuggerCheck",
        "name": "Debugger Check",
        "passed": false
      },
      {
        "id": "org.aerogear.mobile.security.checks.RootedCheck",
        "name": "Rooted Check",
        "passed": false
      },
      {
        "id": "org.aerogear.mobile.security.checks.ScreenLockCheck",
        "name": "Screen Lock Check",
        "passed": false
      }
    ]
  }
}
```

This goes hand in hand with the changes being introduced in https://github.com/aerogear/aerogear-android-sdk/pull/137