### PR TITLE
Change metrics endpoint status code to NO_CONTENT

### DIFF
--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -45,5 +45,5 @@ func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(200)
+	w.WriteHeader(204)
 }

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -64,7 +64,7 @@ func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
 	defer res.Body.Close()
 	_, err = ioutil.ReadAll(res.Body)
 
-	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, 204, res.StatusCode)
 
 	mockMetricsService.AssertExpectations(t)
 }


### PR DESCRIPTION
## Motivation

Returning 200 status with empty content breaks IOS and Android parsers who will expect JSON file. However when returning 204 status code parsers will work fine.
204 is expected status code when no content is returned. 

## Verification

Changes tested on IOS and Android. No adjustments needed in SDK's.

