### PR TITLE
WIP breaking: Add event_type to metrics records

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ docker-compose up
 
 This section shows an example `curl` request which can be used to send some data to the `/metrics` endpoint.
 
+#### Init type metric request
+
 ```
 curl -i -X POST \
   http://localhost:3000/metrics \
@@ -92,6 +94,7 @@ curl -i -X POST \
   -H 'Postman-Token: 87bf2b99-7cdc-8df9-9b2d-6cdcd2932159' \
   -d '{
   "clientId": "453de7432",
+  "type": "init",
   "data": {
     "app": {
       "appId": "com.example.someApp",
@@ -102,6 +105,48 @@ curl -i -X POST \
       "platform": "android",
       "platformVersion": "27"
     }
+  }
+}'
+```
+
+#### Security metric type payload
+```
+curl -i -X POST \
+  http://localhost:3000/metrics \
+  -H 'Cache-Control: no-cache' \
+  -H 'Content-Type: application/json' \
+  -H 'Postman-Token: 87bf2b99-7cdc-8df9-9b2d-6cdcd2932159' \
+  -d '{
+  "clientId": "453de7432",
+  "type": "security",
+  "data": {
+    "security": [
+      {
+        "id": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
+        "name": "Developer Mode Check",
+        "passed": true
+      },
+     {
+        "id": "org.aerogear.mobile.security.checks.EmulatorCheck",
+        "name": "Emulator Check",
+        "passed": false
+      },
+      {
+        "id": "org.aerogear.mobile.security.checks.DebuggerCheck",
+        "name": "Debugger Check",
+        "passed": false
+      },
+      {
+        "id": "org.aerogear.mobile.security.checks.RootedCheck",
+        "name": "Rooted Check",
+        "passed": false
+      },
+      {
+        "id": "org.aerogear.mobile.security.checks.ScreenLockCheck",
+        "name": "Screen Lock Check",
+        "passed": false
+      }
+    ]
   }
 }'
 ```

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -10,8 +10,8 @@ type MetricsDAO struct {
 }
 
 // Create a metrics record
-func (m *MetricsDAO) Create(clientId string, metricsData []byte, clientTime *time.Time) error {
-	_, err := m.db.Exec("INSERT INTO mobileappmetrics(clientId, data, client_time) VALUES($1, $2, $3)", clientId, metricsData, clientTime)
+func (m *MetricsDAO) Create(clientId string, eventType string, metricsData []byte, clientTime *time.Time) error {
+	_, err := m.db.Exec("INSERT INTO mobileappmetrics(clientId, event_type, data, client_time) VALUES($1, $2, $3, $4)", clientId, eventType, metricsData, clientTime)
 	return err
 }
 

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_type varchar(128) NOT NULL CHECK(event_type <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -4,5 +4,5 @@ import "time"
 
 // MetricCreator defines how a metric can be created
 type MetricCreator interface {
-	Create(clientId string, metricsData []byte, clientTime *time.Time) error
+	Create(clientId string, eventType string, metricsData []byte, clientTime *time.Time) error
 }

--- a/pkg/mobile/metrics.go
+++ b/pkg/mobile/metrics.go
@@ -24,11 +24,11 @@ func (m MetricsService) Create(metric Metric) (Metric, error) {
 
 	// happens if timestamp is empty
 	if err != nil {
-		return metric, m.mdao.Create(metric.ClientId, metricsData, nil)
+		return metric, m.mdao.Create(metric.ClientId, metric.EventType, metricsData, nil)
 	}
 
 	// convert to time object
 	clientTime := time.Unix(t, 0)
 
-	return metric, m.mdao.Create(metric.ClientId, metricsData, &clientTime)
+	return metric, m.mdao.Create(metric.ClientId, metric.EventType, metricsData, &clientTime)
 }


### PR DESCRIPTION
## Motivation

<!-- The reason underlying the contents of the PR, can be a link to the originating JIRA -->

JIRA: https://issues.jboss.org/browse/AEROGEAR-2250

## Description

Add EventType field to metrics, split validation of different event types.
Currently added the existing event types as `"init"` and `"security"`, these can be changed.

## Progress

- [x] Add event_type to parsed json payload
- [x] Add event_type to table creation script
- [x] Add validation for different eventTypes
- [x] Update curl examples on readme
- [ ] Update unit tests
