### PR TITLE
WIP breaking: Split metrics records into separate tables

### DIFF
--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -37,14 +37,19 @@ func (m *MetricsDAO) Create(clientId string, metric mobile.Metric, clientTime *t
 	return m.RunInTransaction(func(tx *sql.Tx) error {
 		if metric.Data.App != nil {
 			appMetric := metric.Data.App
-			if _, err := tx.Exec(`INSERT INTO mobilemetrics_app (
+			stmt, err := tx.Prepare(`INSERT INTO mobilemetrics_app (
 				clientId,
 				client_time,
 				event_time,
 				app_id,
 				sdk_version,
 				app_version
-			) VALUES($1, $2, $3, $4, $5, $6)`,
+			) VALUES($1, $2, $3, $4, $5, $6)`)
+			if err != nil {
+				return err
+			}
+
+			if _, err := stmt.Exec(
 				clientId,
 				clientTime,
 				eventTime,
@@ -57,13 +62,17 @@ func (m *MetricsDAO) Create(clientId string, metric mobile.Metric, clientTime *t
 		}
 		if metric.Data.Device != nil {
 			deviceMetric := metric.Data.Device
-			if _, err := tx.Exec(`INSERT INTO mobilemetrics_device (
+			stmt, err := tx.Prepare(`INSERT INTO mobilemetrics_device (
 				clientId,
 				client_time,
 				event_time,
 				platform,
 				platform_version
-			) VALUES($1, $2, $3, $4, $5)`,
+			) VALUES($1, $2, $3, $4, $5)`)
+			if err != nil {
+				return err
+			}
+			if _, err := stmt.Exec(
 				clientId,
 				clientTime,
 				eventTime,
@@ -74,15 +83,19 @@ func (m *MetricsDAO) Create(clientId string, metric mobile.Metric, clientTime *t
 			}
 		}
 		if metric.Data.Security != nil {
+			stmt, err := tx.Prepare(`INSERT INTO mobilemetrics_security (
+				clientId,
+				client_time,
+				event_time,
+				id,
+				name,
+				passed
+			) VALUES($1, $2, $3, $4, $5, $6)`)
+			if err != nil {
+				return err
+			}
 			for _, securityMetric := range *metric.Data.Security {
-				if _, err := tx.Exec(`INSERT INTO mobilemetrics_security (
-					clientId,
-					client_time,
-					event_time,
-					id,
-					name,
-					passed
-				) VALUES($1, $2, $3, $4, $5, $6)`,
+				if _, err := stmt.Exec(
 					clientId,
 					clientTime,
 					eventTime,

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -56,7 +56,9 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 		clientId varchar NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),
-		data jsonb NOT NULL
+		app_id varchar NOT NULL,
+		sdk_version varchar NOT NULL,
+		app_version varchar NOT NULL
 	)`); err != nil {
 		return err
 	}

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -82,11 +82,10 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 		id char(80) NOT NULL,
 		name char(40) NOT NULL,
 		passed boolean,
-		PRIMARY KEY (clientId, event_time)
+		PRIMARY KEY (clientId, event_time, id)
 	)`); err != nil {
 		return err
 	}
 
 	return nil
-
 }

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec(`CREATE TABLE IF NOT EXISTS mobilemetrics_app(
+	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobilemetrics_app(
 		clientId varchar NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),
@@ -63,7 +63,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 		return err
 	}
 
-	if _, err := handler.DB.Exec(`CREATE TABLE IF NOT EXISTS mobilemetrics_device(
+	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobilemetrics_device(
 		clientId varchar NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),
@@ -73,7 +73,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 		return err
 	}
 
-	if _, err := handler.DB.Exec(`CREATE TABLE IF NOT EXISTS mobilemetrics_security(
+	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobilemetrics_security(
 		clientId varchar NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -53,36 +53,40 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
 	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobilemetrics_app(
-		clientId varchar NOT NULL CHECK (clientId <> ''),
+		clientId char(80) NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),
-		app_id varchar NOT NULL,
-		sdk_version varchar NOT NULL,
-		app_version varchar NOT NULL
+		app_id char(40) NOT NULL,
+		sdk_version char(20) NOT NULL,
+		app_version char(20) NOT NULL,
+		PRIMARY KEY (clientId, event_time)
 	)`); err != nil {
 		return err
 	}
 
 	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobilemetrics_device(
-		clientId varchar NOT NULL CHECK (clientId <> ''),
+		clientId char(80) NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),
-		platform varchar NOT NULL,
-		platform_version varchar NOT NULL
+		platform char(20) NOT NULL,
+		platform_version char(20) NOT NULL,
+		PRIMARY KEY (clientId, event_time)
 	)`); err != nil {
 		return err
 	}
 
 	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobilemetrics_security(
-		clientId varchar NOT NULL CHECK (clientId <> ''),
+		clientId char(80) NOT NULL CHECK (clientId <> ''),
 		event_time timestamptz NOT NULL DEFAULT now(),
 		client_time timestamptz DEFAULT now(),
-		id varchar NOT NULL,
-		name varchar NOT NULL,
-		passed boolean
+		id char(80) NOT NULL,
+		name char(40) NOT NULL,
+		passed boolean,
+		PRIMARY KEY (clientId, event_time)
 	)`); err != nil {
 		return err
 	}
+
 	return nil
 
 }

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,8 +52,35 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
+	if _, err := handler.DB.Exec(`CREATE TABLE IF NOT EXISTS mobilemetrics_app(
+		clientId varchar NOT NULL CHECK (clientId <> ''),
+		event_time timestamptz NOT NULL DEFAULT now(),
+		client_time timestamptz DEFAULT now(),
+		data jsonb NOT NULL
+	)`); err != nil {
+		return err
+	}
+
+	if _, err := handler.DB.Exec(`CREATE TABLE IF NOT EXISTS mobilemetrics_device(
+		clientId varchar NOT NULL CHECK (clientId <> ''),
+		event_time timestamptz NOT NULL DEFAULT now(),
+		client_time timestamptz DEFAULT now(),
+		platform varchar NOT NULL,
+		platform_version varchar NOT NULL
+	)`); err != nil {
+		return err
+	}
+
+	if _, err := handler.DB.Exec(`CREATE TABLE IF NOT EXISTS mobilemetrics_security(
+		clientId varchar NOT NULL CHECK (clientId <> ''),
+		event_time timestamptz NOT NULL DEFAULT now(),
+		client_time timestamptz DEFAULT now(),
+		id varchar NOT NULL,
+		name varchar NOT NULL,
+		passed boolean
+	)`); err != nil {
 		return err
 	}
 	return nil
+
 }

--- a/pkg/dao/db_test.go
+++ b/pkg/dao/db_test.go
@@ -91,16 +91,16 @@ func TestDoInitialSetup(t *testing.T) {
 		t.Errorf("DoInitialSetup() returned an error: %s", err.Error())
 	}
 
-	var exists bool
+	var tableCount int
 
-	err = dbHandler.DB.QueryRow("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'mobileappmetrics');").Scan(&exists)
+	err = dbHandler.DB.QueryRow("SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE 'mobilemetrics_%';").Scan(&tableCount)
 
 	if err != nil {
 		t.Errorf("Database returned an error while checking if table exists: %s", err.Error())
 	}
 
-	if !exists {
-		t.Errorf("Expected table mobileappmetrics does not exist")
+	if !tableCount == 3 {
+		t.Errorf("Expected 3 mobilemetrics_ tables, found %v", tableCount)
 	}
 }
 

--- a/pkg/mobile/appmetric.go
+++ b/pkg/mobile/appmetric.go
@@ -1,0 +1,24 @@
+package mobile
+
+type AppMetric struct {
+	ID         string `json:"appId"`
+	SDKVersion string `json:"sdkVersion"`
+	AppVersion string `json:"appVersion"`
+}
+
+const missingIDError = "missing data.app.appId in payload"
+const missingSDKVersionError = "missing data.app.sdkVersion in payload"
+const missingAppVersionError = "missing data.app.appVersion in payload"
+
+func (app *AppMetric) Validate() (valid bool, reason string) {
+	if app.ID == "" {
+		return false, missingIDError
+	}
+	if app.SDKVersion == "" {
+		return false, missingSDKVersionError
+	}
+	if app.AppVersion == "" {
+		return false, missingAppVersionError
+	}
+	return true, ""
+}

--- a/pkg/mobile/devicemetric.go
+++ b/pkg/mobile/devicemetric.go
@@ -1,0 +1,19 @@
+package mobile
+
+type DeviceMetric struct {
+	Platform        string `json:"platform"`
+	PlatformVersion string `json:"platformVersion"`
+}
+
+const missingPlatformError = "missing data.app.appId in payload"
+const missingPlatformVersionError = "missing data.app.sdkVersion in payload"
+
+func (dev *DeviceMetric) Validate() (valid bool, reason string) {
+	if dev.Platform == "" {
+		return false, missingPlatformError
+	}
+	if dev.PlatformVersion == "" {
+		return false, missingPlatformVersionError
+	}
+	return true, ""
+}

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -4,5 +4,5 @@ import "time"
 
 // MetricCreator defines how a metric can be created
 type MetricCreator interface {
-	Create(clientId string, metricsData []byte, clientTime *time.Time) error
+	Create(clientId string, metric Metric, clientTime *time.Time) error
 }

--- a/pkg/mobile/metrics.go
+++ b/pkg/mobile/metrics.go
@@ -1,7 +1,6 @@
 package mobile
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -14,21 +13,15 @@ func NewMetricsService(dao MetricCreator) *MetricsService {
 }
 
 func (m MetricsService) Create(metric Metric) (Metric, error) {
-	metricsData, err := json.Marshal(metric.Data)
-
-	if err != nil {
-		return metric, err
-	}
-
 	t, err := metric.ClientTimestamp.Int64()
 
 	// happens if timestamp is empty
 	if err != nil {
-		return metric, m.mdao.Create(metric.ClientId, metricsData, nil)
+		return metric, m.mdao.Create(metric.ClientId, metric, nil)
 	}
 
 	// convert to time object
 	clientTime := time.Unix(t, 0)
 
-	return metric, m.mdao.Create(metric.ClientId, metricsData, &clientTime)
+	return metric, m.mdao.Create(metric.ClientId, metric, &clientTime)
 }

--- a/pkg/mobile/securitymetric.go
+++ b/pkg/mobile/securitymetric.go
@@ -1,0 +1,28 @@
+package mobile
+
+import "fmt"
+
+type SecurityMetric struct {
+	Id     *string `json:"id,omitempty"`
+	Name   *string `json:"name,omitempty"`
+	Passed *bool   `json:"passed,omitempty"`
+}
+
+const securityMetricsMaxLength = 30
+const missingSecurityError = "missing data.security in security-type payload"
+const securityMetricMissingIdError = "invalid element in data.security at position %v, id must be included"
+const securityMetricMissingNameError = "invalid element in data.security at position %v, name must be included"
+const securityMetricMissingPassedError = "invalid element in data.security at position %v, passed must be included"
+
+func (sm *SecurityMetric) Validate(i int) (valid bool, reason string) {
+	if sm.Id == nil {
+		return false, fmt.Sprintf(securityMetricMissingIdError, i)
+	}
+	if sm.Name == nil {
+		return false, fmt.Sprintf(securityMetricMissingNameError, i)
+	}
+	if sm.Passed == nil {
+		return false, fmt.Sprintf(securityMetricMissingPassedError, i)
+	}
+	return true, ""
+}

--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -17,6 +17,12 @@ func TestMetricValidate(t *testing.T) {
 		bigSecurityMetricList = append(bigSecurityMetricList, SecurityMetric{Id: &securityMetricId, Passed: &securityMetricPassed})
 	}
 
+	validAppMetric := &AppMetric{
+		SDKVersion: "1",
+		ID:         "some-app-id",
+		AppVersion: "1",
+	}
+
 	testCases := []struct {
 		Name           string
 		Metric         Metric
@@ -31,13 +37,13 @@ func TestMetricValidate(t *testing.T) {
 		},
 		{
 			Name:           "Metric with no clientId should be invalid",
-			Metric:         Metric{Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Metric:         Metric{Data: &MetricData{App: validAppMetric}},
 			Valid:          false,
 			ExpectedReason: missingClientIdError,
 		},
 		{
 			Name:           "Metric with long clientId should be invalid",
-			Metric:         Metric{ClientId: strings.Join(make([]string, clientIdMaxLength+10), "a"), Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Metric:         Metric{ClientId: strings.Join(make([]string, clientIdMaxLength+10), "a"), Data: &MetricData{App: validAppMetric}},
 			Valid:          false,
 			ExpectedReason: clientIdLengthError,
 		},
@@ -55,19 +61,19 @@ func TestMetricValidate(t *testing.T) {
 		},
 		{
 			Name:           "Metric with ClientId and Some Data should be valid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{App: validAppMetric}},
 			Valid:          true,
 			ExpectedReason: "",
 		},
 		{
 			Name:           "Metric with bad timestamp should be invalid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", ClientTimestamp: "invalid", Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", ClientTimestamp: "invalid", Data: &MetricData{App: validAppMetric}},
 			Valid:          false,
 			ExpectedReason: invalidTimestampError,
 		},
 		{
 			Name:           "Metric with valid timestamp should be valid",
-			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", ClientTimestamp: "12345", Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", ClientTimestamp: "12345", Data: &MetricData{App: validAppMetric}},
 			Valid:          true,
 			ExpectedReason: "",
 		},


### PR DESCRIPTION
## Motivation
Split metrics tables as result of spike in order to simplify queries and improve extensibility.

Done as part of spike to avoid introducing an `event_type` field in favor of querying on top relations between the different data under `data` that we have.

After investigating the tradeoffs of utilizing JSONB as a primary storage engine for the metrics data I've found some details about performance in relation both to indexing and querying and utilized space and it seems utilizing more traditional schemas can avoid many problems in the long run:

https://heapanalytics.com/blog/engineering/when-to-avoid-jsonb-in-a-postgresql-schema
https://blog.2ndquadrant.com/postgresql-anti-patterns-unnecessary-jsonhstore-dynamic-columns/

Some points:
- JSONB has to store all the key bytes per record instead of on a table header, so records that have the same structure end up having N duplicates of their field names as additional data overhead (i.e. "clientId", "data", etc. in all of our records)
- postgres automatically keeps histogram and totals data for traditional data types, which give huge performance boosts in aggregation queries
- A single table for different metrics records types would make index creation even harder
- JSON query operators are more esoteric and non-standard SQL, so custom queries by end users will need to be more aware and tied into the metrics JSON structure.

JIRA: https://issues.jboss.org/browse/AEROGEAR-2336

## Description

- Extend startup database creation to add tables per-metrics type
- Fan out creation of records in the separate tables in a transaction-wrapped set of instructions in the DAO

Under these changes the HTTP API is unchanged but the data is created as separate records for each key under `data`.

- `data.app` goes to `mobilemetrics_app`
- `data.device` goes to `mobilemetrics_device`
- `data.security` goes to `mobilemetrics_security`, as 1 record per item in the array

i.e. the following request:

```
curl -i -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 87bf2b99-7cdc-8df9-9b2d-6cdcd2932159' \
  -d '{
  "clientId": "453de7432",
  "data": {
    "app": {
      "appId": "com.example.someApp",
      "sdkVersion": "2.4.6",
      "appVersion": "256"
    },
    "device": {
      "platform": "android",
      "platformVersion": "27"
    },
    "security": [
      {
        "id": "org.aerogear.mobile.security.checks.DeveloperModeCheck",
        "name": "Developer Mode Check",
        "passed": true
      },
     {
        "id": "org.aerogear.mobile.security.checks.EmulatorCheck",
        "name": "Emulator Check",
        "passed": false
      },
      {
        "id": "org.aerogear.mobile.security.checks.DebuggerCheck",
        "name": "Debugger Check",
        "passed": false
      },
      {
        "id": "org.aerogear.mobile.security.checks.RootedCheck",
        "name": "Rooted Check",
        "passed": false
      },
      {
        "id": "org.aerogear.mobile.security.checks.ScreenLockCheck",
        "name": "Screen Lock Check",
        "passed": false
      }
    ]
  }
}'
```

Is valid and creates the following records:

**mobilemetrics_app**:
```
+------------+-------------------------------+---------------+---------------------+---------------+---------------+
| clientid   | event_time                    |   client_time | app_id              | sdk_version   | app_version   |
|------------+-------------------------------+---------------+---------------------+---------------+---------------|
| 453de7432  | 2018-03-12 13:21:29.115368+00 |        <null> | com.example.someApp | 2.4.6         | 256           |
+------------+-------------------------------+---------------+---------------------+---------------+---------------+
```

**mobilemetrics_device**:
```
+------------+-------------------------------+---------------+------------+--------------------+
| clientid   | event_time                    |   client_time | platform   | platform_version   |
|------------+-------------------------------+---------------+------------+--------------------|
| 453de7432  | 2018-03-12 13:21:29.115368+00 |        <null> | android    | 27                 |
+------------+-------------------------------+---------------+------------+--------------------+
```

**mobilemetrics_security**:
```
+------------+-------------------------------+---------------+--------------------------------------------------------+----------------------+----------+
| clientid   | event_time                    |   client_time | id                                                     | name                 | passed   |
|------------+-------------------------------+---------------+--------------------------------------------------------+----------------------+----------|
| 453de7432  | 2018-03-12 13:24:40.273127+00 |        <null> | org.aerogear.mobile.security.checks.DeveloperModeCheck | Developer Mode Check | True     |
| 453de7432  | 2018-03-12 13:24:40.273127+00 |        <null> | org.aerogear.mobile.security.checks.EmulatorCheck      | Emulator Check       | False    |
| 453de7432  | 2018-03-12 13:24:40.273127+00 |        <null> | org.aerogear.mobile.security.checks.DebuggerCheck      | Debugger Check       | False    |
| 453de7432  | 2018-03-12 13:24:40.273127+00 |        <null> | org.aerogear.mobile.security.checks.RootedCheck        | Rooted Check         | False    |
| 453de7432  | 2018-03-12 13:24:40.273127+00 |        <null> | org.aerogear.mobile.security.checks.ScreenLockCheck    | Screen Lock Check    | False    |
+------------+-------------------------------+---------------+--------------------------------------------------------+----------------------+----------+
```

Table names not final.

## Progress

- [x] Create new tables in startup
- [x] Change metrics Create() to add record to mobilemetrics_app
- [x] Change metrics Create() to add record to mobilemetrics_device
- [x] Change metrics Create() to add record to mobilemetrics_security
- [ ] Update unit tests

