### PR TITLE
Add PK and the UNLOGGED flag to mobileappmetrics table

### DIFF
--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,13 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE UNLOGGED TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
+	if _, err := handler.DB.Exec(`CREATE UNLOGGED TABLE IF NOT EXISTS mobileappmetrics (
+		clientId char(80) NOT NULL CHECK (clientId <> ''),
+		event_time timestamptz NOT NULL DEFAULT now(),
+		client_time timestamptz DEFAULT now(),
+		data jsonb NOT NULL,
+		PRIMARY KEY(clientId, event_time)
+		)`); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -52,7 +52,7 @@ func (handler *DatabaseHandler) DoInitialSetup() error {
 	if handler.DB == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := handler.DB.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
+	if _, err := handler.DB.Exec("CREATE UNLOGGED TABLE IF NOT EXISTS mobileappmetrics(clientId varchar NOT NULL CHECK (clientId <> ''), event_time timestamptz NOT NULL DEFAULT now(), client_time timestamptz DEFAULT now(), data jsonb NOT NULL)"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Motivation

A couple changes to the table initialization to improve querying support.

Benchmarks have suggested this doesn't decrease insertion performance a noticeable level.

## Description

Add PK and the UNLOGGED flag to the mobileappmetrics table
