### PR TITLE
feat: OpenShift template

### DIFF
--- a/openshift-template.yml
+++ b/openshift-template.yml
@@ -1,0 +1,149 @@
+---
+# PV configuration commented out (see below)
+apiVersion: v1
+kind: Template
+metadata:
+  name: test
+objects:
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: aerogear-app-metrics
+      service: aerogear-app-metrics
+    name: aerogear-app-metrics
+  spec:
+    ports:
+    - name: web
+      port: 443
+      targetPort: 3000
+    selector:
+      app: aerogear-app-metrics
+      service: aerogear-app-metrics
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: postgres
+      app: aerogear-app-metrics
+    name: postgres-internal
+  spec:
+    ports:
+    - name: 5432-tcp
+      port: 5432
+      targetPort: 5432
+    selector:
+      app: postgres
+      service: aerogear-app-metrics
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: aerogear-app-metrics
+      service: aerogear-app-metrics
+    name: aerogear-app-metrics
+  spec:
+    port:
+      targetPort: web
+    to:
+      kind: Service
+      name: aerogear-app-metrics
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: aerogear-app-metrics
+      service: aerogear-app-metrics
+    name: aerogear-app-metrics
+  spec:
+    replicas: 1
+    selector:
+      app: aerogear-app-metrics
+      service: aerogear-app-metrics
+    template:
+      metadata:
+        labels:
+          app: aerogear-app-metrics
+          service: aerogear-app-metrics
+      spec:
+        containers:
+        - env:
+          - name: PGHOST
+            value: postgres-internal
+          - name: PGUSER
+            value: postgresql
+          - name: PGPASSWORD
+            value: postgres
+          - name: PGDATABASE
+            value: aerogear_mobile_metrics
+          image: docker.io/aerogear/aerogear-app-metrics
+          imagePullPolicy: Always
+          name: aerogear-app-metrics
+          ports:
+          - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: healthz
+              port: 3000
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: postgres
+      service: aerogear-app-metrics
+    name: postgres
+  spec:
+    replicas: 1
+    selector:
+      app: postgres
+      service: aerogear-app-metrics
+    template:
+      metadata:
+        labels:
+          app: postgres
+          service: aerogear-app-metrics
+      spec:
+        containers:
+        - env:
+          - name: POSTGRESQL_DATABASE
+            value: aerogear_mobile_metrics
+          - name: POSTGRESQL_PASSWORD
+            value: postgres
+          - name: POSTGRESQL_USER
+            value: postgresql
+          image: registry.access.redhat.com/rhscl/postgresql-96-rhel7
+          imagePullPolicy: IfNotPresent
+          name: postgresql
+          ports:
+          - containerPort: 5432
+#          volumeMounts:
+#          - mountPath: /var/lib/pgsql/data
+#            name: postgres-volume
+#        volumes:
+#        - name: postgres-volume
+#          persistentVolumeClaim:
+#            claimName: postgres-pvc
+#- apiVersion: v1
+#  kind: PersistentVolumeClaim
+#  metadata:
+#    name: postgres-pvc
+#    labels:
+#      app: aerogear-app-metrics
+#      service: aerogear-app-metrics
+#  spec:
+#    accessModes:
+#    - ReadWriteMany
+#    resources:
+#      requests:
+#        storage: 10Gi
+


### PR DESCRIPTION
## Description

Added OpenShift template

## Motivation

As we're using app-metrics template for integration tests in 2 repos,
(https://github.com/aerogear/aerogear-android-sdk/pull/127, https://github.com/aerogear/aerogear-ios-sdk/pull/54) it would be reasonable to keep and maintain the template in one place.

The template was created according to the [provisioning role](https://github.com/aerogearcatalog/metrics-apb/blob/master/roles/provision-metrics-apb/tasks/provision-app-metrics.yml) in metrics-apb.

## Additional Notes

<!-- Optional, extra context or instructions, e.g. steps for manual testing -->

You can verify it with running `oc new-app -f openshift-template.yml` in empty project of your OpenShift cluster.

Then run the curl command to create a record in db:
```
curl -X POST \                                                                                                                          ⬡ 6.11.3 [±feat-openshift-template ✓]
  https://<your-app-metrics-route>/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 76a14738-976f-f0ea-4039-12efeebf4f1e' \
  -d '{
  "clientId": "123456",
  "data": {
        "app": {
    "id": "com.example.someApp",
    "sdkVersion": "2.2.6",
    "appVersion": "256"
        },
        "device": {
        "platform": "ios",
        "platformVersion": "27"
        }
  }
}'
```
