### PR TITLE
fix: use master version of the image in template

### DIFF
--- a/openshift-template.yml
+++ b/openshift-template.yml
@@ -83,7 +83,7 @@ objects:
             value: postgres
           - name: PGDATABASE
             value: aerogear_mobile_metrics
-          image: docker.io/aerogear/aerogear-app-metrics
+          image: docker.io/aerogear/aerogear-app-metrics:master
           imagePullPolicy: Always
           name: aerogear-app-metrics
           ports:


### PR DESCRIPTION
## Description

Use `master` version of docker image in template

## Motivation

Integration tests implemented in ios-sdk and android-sdk repos are using this template for testing and they should use the newest version of the app metrics docker image, which is [master](https://hub.docker.com/r/aerogear/aerogear-app-metrics/tags/)

`latest` image is ~1 month old