### PR TITLE
Enable cors requests

### DIFF
--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -38,9 +38,6 @@ func main() {
 
 	// allow CORS for localhost
 	handler := cors.New(cors.Options{
-		AllowedOrigins:   []string{"*"},
-		AllowedHeaders:   []string{"X-Requested-With"},
-		AllowedMethods:   []string{"GET", "HEAD", "POST", "PUT", "OPTIONS"},
 		AllowCredentials: true,
 	}).Handler(router)
 

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -38,7 +38,9 @@ func main() {
 
 	// allow CORS for localhost
 	handler := cors.New(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:8080"},
+		AllowedOrigins:   []string{"*"},
+		AllowedHeaders:   []string{"X-Requested-With"},
+		AllowedMethods:   []string{"GET", "HEAD", "POST", "PUT", "OPTIONS"},
 		AllowCredentials: true,
 	}).Handler(router)
 

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -17,13 +17,6 @@ func NewMetricsHandler(ms MetricsServiceInterface) *metricsHandler {
 	return &metricsHandler{metricService: ms}
 }
 
-func (mh *metricsHandler) MetricOptions(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Headers", "*")
-	w.WriteHeader(200)
-}
-
 func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
@@ -51,7 +44,5 @@ func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 		boom.BadImplementation(w)
 		return
 	}
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	w.WriteHeader(204)
 }

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -17,6 +17,13 @@ func NewMetricsHandler(ms MetricsServiceInterface) *metricsHandler {
 	return &metricsHandler{metricService: ms}
 }
 
+func (mh *metricsHandler) MetricOptions(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+	w.WriteHeader(200)
+}
+
 func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
@@ -44,6 +51,7 @@ func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 		boom.BadImplementation(w)
 		return
 	}
-
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	w.WriteHeader(204)
 }

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -47,7 +47,6 @@ func MetricsRoute(r *mux.Router, handler *metricsHandler) {
 	//   '500':
 	//     description: Server Error
 	r.HandleFunc("/metrics", handler.CreateMetric).Methods("POST")
-	r.HandleFunc("/metrics", handler.MetricOptions).Methods("OPTIONS")
 }
 
 func HealthzRoute(r *mux.Router, handler *healthHandler) {

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -47,6 +47,7 @@ func MetricsRoute(r *mux.Router, handler *metricsHandler) {
 	//   '500':
 	//     description: Server Error
 	r.HandleFunc("/metrics", handler.CreateMetric).Methods("POST")
+	r.HandleFunc("/metrics", handler.MetricOptions).Methods("OPTIONS")
 }
 
 func HealthzRoute(r *mux.Router, handler *healthHandler) {


### PR DESCRIPTION
## Description

Allow to use metrics api with CORS that is by default enabled for the web.
Since multiple users with multiple different IP ranges needs to call this server using Cors with any other value that * makes no sense here. 

# Verification

Run server with docker compose and try it out with cordova example app.